### PR TITLE
Refactor TypeScript interfaces to centralized types directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,15 @@ shop/
 │   │   ├── ProductRow.tsx           # Product display row component
 │   │   └── ProductRow.module.css    # Product row styles
 │   ├── hooks/                       # Custom React hooks
+│   │   ├── useMutateProducts.ts     # Product mutation hook
 │   │   └── useProducts.ts           # Products data fetching hook
 │   ├── products/                    # Products section
 │   │   ├── page.tsx                 # Product display page
 │   │   └── page.module.css          # Products page styles
+│   ├── types/                       # TypeScript type definitions
+│   │   ├── index.ts                 # Central export point for types
+│   │   ├── hooks.ts                 # Hook return type interfaces
+│   │   └── product.ts               # Product-related interfaces
 │   ├── globals.css                  # Global styles and CSS variables
 │   ├── layout.tsx                   # Root layout component
 │   ├── page.tsx                     # Home page component
@@ -52,6 +57,8 @@ shop/
 - Keep components in the `app/` directory following the App Router structure
 - Use CSS modules for component-specific styling
 - Utilize global CSS variables for consistent theming
+- Centralize TypeScript interfaces in `app/types/` directory
+- Import types from `app/types` for reusability across components
 
 ## Testing
 

--- a/app/components/ProductRow.tsx
+++ b/app/components/ProductRow.tsx
@@ -1,17 +1,6 @@
 import styles from './ProductRow.module.css';
 import CartCounter from './CartCounter';
-
-interface Product {
-  id: number;
-  name: string;
-  price: number;
-  originalPrice: number;
-  image: string;
-  rating: number;
-  reviews: number;
-  description: string;
-  discount : number;
-}
+import { Product } from '../types';
 
 interface ProductRowProps {
   product: Product;

--- a/app/hooks/useMutateProducts.ts
+++ b/app/hooks/useMutateProducts.ts
@@ -2,24 +2,7 @@
 
 import { useState } from 'react';
 import axios from 'axios';
-
-interface Product {
-  id: number;
-  name: string;
-  price: number;
-  originalPrice: number;
-  image: string;
-  rating: number;
-  reviews: number;
-  description: string;
-  discount: number;
-}
-
-interface UseMutateProductsReturn {
-  createProduct: (product: Omit<Product, 'id' | 'discount'>) => Promise<Product | null>;
-  loading: boolean;
-  error: string | null;
-}
+import { Product, UseMutateProductsReturn } from '../types';
 
 export default function useMutateProducts(): UseMutateProductsReturn {
   const [loading, setLoading] = useState<boolean>(false);

--- a/app/hooks/useProducts.ts
+++ b/app/hooks/useProducts.ts
@@ -2,24 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-
-interface Product {
-  id: number;
-  name: string;
-  price: number;
-  originalPrice: number;
-  image: string;
-  rating: number;
-  reviews: number;
-  description: string;
-  discount: number;
-}
-
-interface UseProductsReturn {
-  products: Product[];
-  loading: boolean;
-  error: string | null;
-}
+import { Product, UseProductsReturn } from '../types';
 
 export default function useProducts(): UseProductsReturn {
   const [products, setProducts] = useState<Product[]>([]);

--- a/app/types/hooks.ts
+++ b/app/types/hooks.ts
@@ -1,0 +1,17 @@
+// Hook-related type definitions
+import { Product } from './product';
+
+export interface UseProductsReturn {
+  products: Product[];
+  loading: boolean;
+  error: string | null;
+}
+
+export interface UseMutateProductsReturn {
+  createProduct: (product: Omit<Product, 'id' | 'discount'>) => Promise<Product | null>;
+  loading: boolean;
+  error: string | null;
+}
+
+// You can add more hook-related types here in the future
+// export interface UseCartReturn { ... }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,0 +1,3 @@
+// Central export point for all types
+export * from './product';
+export * from './hooks';

--- a/app/types/product.ts
+++ b/app/types/product.ts
@@ -1,0 +1,17 @@
+// Product-related type definitions
+
+export interface Product {
+  id: number;
+  name: string;
+  price: number;
+  originalPrice: number;
+  image: string;
+  rating: number;
+  reviews: number;
+  description: string;
+  discount: number;
+}
+
+// You can add more product-related types here in the future
+// export interface ProductCategory { ... }
+// export interface ProductReview { ... }


### PR DESCRIPTION
Title: Refactor TypeScript interfaces to centralized types directory

  Description:
  ## Summary
  - Created centralized `app/types/` directory for all TypeScript interfaces
  - Moved Product interface from individual components to `app/types/product.ts`
  - Added hook return type interfaces in `app/types/hooks.ts`
  - Updated all components and hooks to import types from centralized location
  - Updated project documentation to reflect new type organization

  ## Test plan
  - [ ] Verify all components compile without TypeScript errors
  - [ ] Run `npm run build` to ensure production build succeeds
  - [ ] Run `npm run lint` to verify code style compliance
  - [ ] Test product display functionality on `/products` page
  - [ ] Verify hooks continue to work correctly with centralized types